### PR TITLE
update rubocop testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.rake_tasks~
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--order=random

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,3 @@
 Metrics/LineLength:
   Max: 120
 
-Style/StringLiterals:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
 Metrics/LineLength:
   Max: 120
+
+Style/StringLiterals:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: ruby
+sudo: false
+cache: bundler
+
 rvm:
-  - 2.0.0
-script: bundle exec rake
+  - 2.0
+  - 2.2
+
+script:
+  - bundle exec rake rubocop
+  - bundle exec rake
+
 before_install:
   - gem update --system
 services:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "rubocop/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
+
+RuboCop::RakeTask.new
 
 task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
-require "rubocop/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/lib/lita/alias/alias_store.rb
+++ b/lib/lita/alias/alias_store.rb
@@ -23,7 +23,7 @@ module Lita
       # @raises ArgumentError if the alias is not valid
       # @return AliasedCommand The saved alias
       def add(aliased_command)
-        fail AliasAddException, "The alias is not valid" unless aliased_command.valid?
+        fail AliasAddException, 'The alias is not valid' unless aliased_command.valid?
 
         @redis.hset(STORE_KEY, aliased_command.name, aliased_command.command)
       end

--- a/lib/lita/alias/chat_handler.rb
+++ b/lib/lita/alias/chat_handler.rb
@@ -33,8 +33,8 @@ module Lita
 
       ##########################
       # Event Handlers
-      def load_aliases(payload)
-        log.debug("Loading aliases")
+      def load_aliases(_payload)
+        log.debug('Loading aliases')
         alias_store.list.each do |ac|
           add_alias_route(ac)
         end

--- a/lib/lita/alias/chat_handler.rb
+++ b/lib/lita/alias/chat_handler.rb
@@ -115,11 +115,11 @@ module Lita
       end
 
       def delete_alias_route(aliased_command)
-        self.class.routes.delete_if {|route| route.pattern.match(aliased_command.name) }
+        self.class.routes.delete_if { |route| route.pattern.match(aliased_command.name) }
       end
 
       def alias_route_exists?(aliased_command)
-        self.class.routes.any? {|route| route.pattern.match(aliased_command.name) }
+        self.class.routes.any? { |route| route.pattern.match(aliased_command.name) }
       end
     end
 

--- a/lita-alias.gemspec
+++ b/lita-alias.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.metadata      = { "lita_plugin_type" => "handler" }
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]

--- a/lita-alias.gemspec
+++ b/lita-alias.gemspec
@@ -1,27 +1,27 @@
 Gem::Specification.new do |spec|
-  spec.name          = "lita-alias"
-  spec.version       = "0.0.1"
-  spec.authors       = ["Alex Soto"]
-  spec.email         = ["apsoto@gmail.com"]
-  spec.description   = "A Lita Chatbot plugin to alias commands."
-  spec.summary       = "A Lita Chatbot plugin to alias commands."
-  spec.homepage      = "https://github.com/apsoto/lita-alias"
-  spec.license       = "MIT"
-  spec.metadata      = { "lita_plugin_type" => "handler" }
+  spec.name          = 'lita-alias'
+  spec.version       = '0.0.1'
+  spec.authors       = ['Alex Soto']
+  spec.email         = ['apsoto@gmail.com']
+  spec.description   = 'A Lita Chatbot plugin to alias commands.'
+  spec.summary       = 'A Lita Chatbot plugin to alias commands.'
+  spec.homepage      = 'https://github.com/apsoto/lita-alias'
+  spec.license       = 'MIT'
+  spec.metadata      = { 'lita_plugin_type' => 'handler' }
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency "lita", ">= 4.3"
+  spec.add_runtime_dependency 'lita', '>= 4.3'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rack-test"
-  spec.add_development_dependency "rspec", ">= 3.0.0"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rack-test'
+  spec.add_development_dependency 'rspec', '>= 3.0.0'
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'rubocop'
 end

--- a/spec/lita/alias/chat_handler_spec.rb
+++ b/spec/lita/alias/chat_handler_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Lita::Alias::ChatHandler, lita_handler: true do
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,13 @@
-require "simplecov"
-require "coveralls"
+require 'simplecov'
+require 'coveralls'
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]
-SimpleCov.start { add_filter "/spec/" }
+SimpleCov.start { add_filter '/spec/' }
 
-require "lita-alias"
-require "lita/rspec"
+require 'lita-alias'
+require 'lita/rspec'
 
 # A compatibility mode is provided for older plugins upgrading from Lita 3. Since this plugin
 # was generated with Lita 4, the compatibility mode should be left disabled.


### PR DESCRIPTION
instead of changing the style of quotes, adds a rule to allow.

Sets up travis testing to be speedy via containers and caches.

I left one rubocop test failing - as it looks to be a behavioral change in `load_aliases(payload)` - I'll likely dig into this further as I shim in more testing.