### PR TITLE
update internal command to support no robot alias

### DIFF
--- a/lib/lita/alias/chat_handler.rb
+++ b/lib/lita/alias/chat_handler.rb
@@ -28,8 +28,6 @@ module Lita
             command: true,
             help: { 'alias delete NAME' => 'Delete the alias with NAME' }
            )
-      route(/alias\s+test/, :test_alias, command: true)
-      route(/alias\s+foo/, :foo, command: true)
 
       ##########################
       # Event Handlers
@@ -59,7 +57,7 @@ module Lita
 
       def trigger_alias(response)
         ac = alias_store.lookup(response.match_data[1])
-        message = Lita::Message.new(robot, "#{robot.alias}#{ac.command}", response.message.source)
+        message = Lita::Message.new(robot, "#{robot.mention_name} #{ac.command}", response.message.source)
         robot.receive(message)
       end
 
@@ -90,19 +88,6 @@ module Lita
       # @return AliasStore
       def alias_store
         @alias_store ||= AliasStore.new(redis)
-      end
-
-      def test_alias(response)
-        command = redis.hgetall(REDIS_ALIASES_KEY).first.last
-        message = Lita::Message.new(robot, command, response.message.source)
-        after(5) do
-          response.reply "Sending #{command}"
-          robot.receive(message)
-        end
-      end
-
-      def foo(response)
-        response.reply 'foo'
       end
 
       private

--- a/lita-alias.gemspec
+++ b/lita-alias.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'fakeredis'
 end

--- a/spec/lita/alias/aliased_command_spec.rb
+++ b/spec/lita/alias/aliased_command_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Lita::Alias::AliasedCommand do
+  context 'an empty object' do
+    let(:dummy) { subject.class.new }
+
+    it '#valid?' do
+      expect(dummy.valid?).to be_falsey
+    end
+
+    it '#name' do
+      expect(dummy.name).to be_nil
+    end
+  end
+
+  context 'an invalid named object' do
+    let(:dummy) { subject.class.new('someobj') }
+
+    it '#valid?' do
+      expect(dummy.valid?).to be_falsey
+    end
+    it '#name' do
+      expect(dummy.name).to eq 'someobj'
+    end
+    it '#command' do
+      expect(dummy.command).to be_nil
+    end
+  end
+
+  context 'a named object with a command' do
+    let(:dummy) { subject.class.new('some', 'important command') }
+
+    it '#valid?' do
+      expect(dummy.valid?).to be_truthy
+    end
+    it '#name' do
+      expect(dummy.name).to eq 'some'
+    end
+    it '#command' do
+      expect(dummy.command).to eq 'important command'
+    end
+  end
+end

--- a/spec/lita/alias/chat_handler_spec.rb
+++ b/spec/lita/alias/chat_handler_spec.rb
@@ -1,4 +1,81 @@
 require 'spec_helper'
 
 describe Lita::Alias::ChatHandler, lita_handler: true do
+  context 'routes' do
+    it 'receives commands and routes them' do
+      expect(described_class).to route_command('alias add FOO BAR').to :add
+      expect(described_class).to route_command('alias list').to :list
+      expect(described_class).to route_command('alias delete FOO').to :delete
+    end
+
+    it 'does not take action when not spoken to directly' do
+      expect(described_class).not_to route('alias add FOO BAR')
+    end
+
+    it 'does not route another plugin command' do
+      expect(described_class).to_not route_command('sandwich')
+    end
+  end
+
+  context 'commands' do
+    before do
+      # We need a valid command to alias against and validate behavior
+      registry.register_handler(:echo) do
+        route(/^echo\s+(.+)/) do |response|
+          response.reply(response.match_data[1])
+        end
+      end
+    end
+
+    describe 'alias list' do
+      it 'returns an empty list' do
+        send_command('alias list')
+        expect(replies.last).to eq 'No aliases have been saved'
+      end
+      it 'returns current listing' do
+        send_command('alias add FOO echo BAR')
+        send_command('alias list')
+        expect(replies.last).to eq ['FOO => echo BAR']
+      end
+    end
+
+    describe 'alias add' do
+      context 'new' do
+        it 'sets and responds' do
+          send_command('alias add FOO echo BAR')
+          expect(replies.last).to eq "Added alias 'FOO' for 'echo BAR'"
+          send_command('FOO')
+          expect(replies.last).to eq 'BAR'
+        end
+      end
+
+      context 'existing alias' do
+        it 'overrides stored alias' do
+          send_command('alias add foobar echo FOOBAR')
+          expect(replies.last).to eq "Added alias 'foobar' for 'echo FOOBAR'"
+          send_command('alias add foobar echo BARFOO')
+          expect(replies.last).to eq "Added alias 'foobar' for 'echo BARFOO'"
+          send_command('foobar')
+          expect(replies.last).to eq 'BARFOO'
+          expect(replies.include? 'FOOBAR').to be_falsey
+        end
+      end
+    end
+
+    describe 'alias delete' do
+      context 'no alias exists' do
+        it 'repsonds with an error message' do
+          send_command('alias delete bar')
+          expect(replies.last).to eq "Alias 'bar' does not exist"
+        end
+      end
+      context 'an existing alias' do
+        it 'responds with a delete message' do
+          send_command('alias add bar BAZ')
+          send_command('alias delete bar')
+          expect(replies.last).to eq "Deleted alias 'bar' => 'BAZ'"
+        end
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,12 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
 ]
 SimpleCov.start { add_filter '/spec/' }
 
+require 'fakeredis/rspec' unless ENV['CI']
+
 require 'lita-alias'
 require 'lita/rspec'
+
+require 'pry'
 
 # A compatibility mode is provided for older plugins upgrading from Lita 3. Since this plugin
 # was generated with Lita 4, the compatibility mode should be left disabled.


### PR DESCRIPTION
In environments where a robot alias is not configured, or adapters that
disallow the use of `/` as a starting point (Slack), the internal
messaging breaks silently, as there's no alias lisenting.

Adds a bunch of spec tests.