### PR TITLE
add global command flag to alias add

### DIFF
--- a/lib/lita/alias/aliased_command.rb
+++ b/lib/lita/alias/aliased_command.rb
@@ -2,18 +2,26 @@ module Lita
   module Alias
     # A single aliased command
     class AliasedCommand
-      attr_accessor :name, :command
+      attr_accessor :name, :command, :global_flag
 
-      def initialize(name = nil, command = nil)
+      def initialize(name = nil, command = nil, global_flag = nil)
         @name = name
         @command = command
+        @global_flag = global_flag
       end
 
       # Returns true if the object is valid.  False otherwise
       # @return Boolean
+      # @todo this currently returns a String or Nil, not a Boolean.
       def valid?
         # for now, just validate the name and command are not nil
         @name && @command
+      end
+
+      # Returns true if the command is a global command. False otherwise
+      # @return Boolean
+      def global?
+        !@global_flag.nil?
       end
     end
   end

--- a/lib/lita/alias/chat_handler.rb
+++ b/lib/lita/alias/chat_handler.rb
@@ -104,10 +104,12 @@ module Lita
       def add_alias_route(aliased_command)
         return if alias_route_exists?(aliased_command)
 
-        # Decide whether ot not this is a command or message
-        command_truefalse = !aliased_command.global?
-
-        self.class.route(/^(#{aliased_command.name})/, :trigger_alias, command: command_truefalse)
+        self.class.route(
+          /^(#{aliased_command.name})/,
+          :trigger_alias,
+          # Decide whether ot not this is a command or message
+          command: !aliased_command.global?
+        )
         log.debug("Added route for alias '#{aliased_command.name}'")
       end
 

--- a/spec/lita/alias/aliased_command_spec.rb
+++ b/spec/lita/alias/aliased_command_spec.rb
@@ -27,6 +27,20 @@ describe Lita::Alias::AliasedCommand do
     end
   end
 
+  context 'invalid, command only' do
+    let(:dummy) { subject.class.new(nil, 'somecommand') }
+
+    it '#name' do
+      expect(dummy.name).to be nil
+    end
+    it '#command' do
+      expect(dummy.command).to eq 'somecommand'
+    end
+    it '#valid?' do
+      expect(dummy.valid?).to be_falsey
+    end
+  end
+
   context 'a named object with a command' do
     let(:dummy) { subject.class.new('some', 'important command') }
 

--- a/spec/lita/alias/aliased_command_spec.rb
+++ b/spec/lita/alias/aliased_command_spec.rb
@@ -39,5 +39,25 @@ describe Lita::Alias::AliasedCommand do
     it '#command' do
       expect(dummy.command).to eq 'important command'
     end
+    it '#global?' do
+      expect(dummy.global?).to be false
+    end
+  end
+
+  context 'a global command' do
+    let(:dummy) { subject.class.new('some', 'more important command', '--global') }
+
+    it '#valid?' do
+      expect(dummy.valid?).to be_truthy
+    end
+    it '#name' do
+      expect(dummy.name).to eq 'some'
+    end
+    it '#command' do
+      expect(dummy.command).to eq 'more important command'
+    end
+    it '#global?' do
+      expect(dummy.global?).to be true
+    end
   end
 end

--- a/spec/lita/alias/chat_handler_spec.rb
+++ b/spec/lita/alias/chat_handler_spec.rb
@@ -4,6 +4,7 @@ describe Lita::Alias::ChatHandler, lita_handler: true do
   context 'routes' do
     it 'receives commands and routes them' do
       expect(described_class).to route_command('alias add FOO BAR').to :add
+      expect(described_class).to route_command('alias add --global BAZ QUUX').to :add
       expect(described_class).to route_command('alias list').to :list
       expect(described_class).to route_command('alias delete FOO').to :delete
     end
@@ -58,6 +59,15 @@ describe Lita::Alias::ChatHandler, lita_handler: true do
           send_command('foobar')
           expect(replies.last).to eq 'BARFOO'
           expect(replies.include? 'FOOBAR').to be_falsey
+        end
+      end
+
+      context 'global alias' do
+        it 'sets a global alias' do
+          send_command('alias add --global barfoo echo BARFOO')
+          expect(replies.last).to eq "Added alias 'barfoo' for 'echo BARFOO'"
+          send_message('barfoo')
+          expect(replies.last).to eq 'BARFOO'
         end
       end
     end


### PR DESCRIPTION
Works with exisiting aliases and extends the command syntax to capture
the global flag and pass that along to AliasedCommand.

Updates `add_alias_route` to make the decision on whether it should match
a command or message listener.

Not working yet: after restarting process, load_aliases does not register
global aliases, as the state is not persisted.