### PR TITLE
add test for invalid AliasedCommand

### DIFF
--- a/spec/lita/alias/aliased_command_spec.rb
+++ b/spec/lita/alias/aliased_command_spec.rb
@@ -27,6 +27,20 @@ describe Lita::Alias::AliasedCommand do
     end
   end
 
+  context 'invalid, command only' do
+    let(:dummy) { subject.class.new(nil, 'somecommand') }
+
+    it '#name' do
+      expect(dummy.name).to be nil
+    end
+    it '#command' do
+      expect(dummy.command).to eq 'somecommand'
+    end
+    it '#valid?' do
+      expect(dummy.valid?).to be_falsey
+    end
+  end
+
   context 'a named object with a command' do
     let(:dummy) { subject.class.new('some', 'important command') }
 


### PR DESCRIPTION
Discovered with mutant testing, bringing this class to 100% free of
mutants!

It's unlikely that we would ever generate an AliasedCommand without a
name attribute, but if it ever happened, this test would uncover that.