### PR TITLE
Allow alias to accept arguments

### DIFF
--- a/lib/lita/alias/chat_handler.rb
+++ b/lib/lita/alias/chat_handler.rb
@@ -57,7 +57,8 @@ module Lita
 
       def trigger_alias(response)
         ac = alias_store.lookup(response.match_data[1])
-        message = Lita::Message.new(robot, "#{robot.mention_name} #{ac.command}", response.message.source)
+        opts = response.args.join("' '")
+        message = Lita::Message.new(robot, "#{robot.mention_name} #{ac.command} #{opts}", response.message.source)
         robot.receive(message)
       end
 


### PR DESCRIPTION
This is handy when aliasing a script that accepts arguments.
