### PR TITLE
Send alias extra arguments to original command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Adds an alias so when you type the command `/ALIAS` the COMMAND is sent instead 
 
 Example: `/alias add stats_prod hk run my-company-production ./bin/refresh_cache`
 
+**Extra arguments** given to the invoked ALIAS will be appended to the original COMMAND.
+
+```
+/alias add build jenkins job build
+/build my-project   # Executes: /jenkins job build my-project
+```
+
 ### delete
 
     /alias delete ALIAS

--- a/lib/lita/alias/chat_handler.rb
+++ b/lib/lita/alias/chat_handler.rb
@@ -57,7 +57,8 @@ module Lita
 
       def trigger_alias(response)
         ac = alias_store.lookup(response.match_data[1])
-        message = Lita::Message.new(robot, "#{robot.mention_name} #{ac.command}", response.message.source)
+        body = "#{robot.mention_name} #{ac.command} #{response.args.join(' ')}".rstrip
+        message = Lita::Message.new(robot, body, response.message.source)
         robot.receive(message)
       end
 

--- a/lib/lita/alias/chat_handler.rb
+++ b/lib/lita/alias/chat_handler.rb
@@ -95,16 +95,17 @@ module Lita
       def add_alias_route(aliased_command)
         return if alias_route_exists?(aliased_command)
 
-        self.class.route(/^(#{aliased_command.name})/, :trigger_alias, command: true)
+        alias_name = aliased_command.name
+        self.class.route(/^(#{alias_name})(\s|\z)/, :trigger_alias, command: true, alias_name: alias_name)
         log.debug("Added route for alias '#{aliased_command.name}'")
       end
 
       def delete_alias_route(aliased_command)
-        self.class.routes.delete_if { |route| route.pattern.match(aliased_command.name) }
+        self.class.routes.delete_if { |route| route.extensions[:alias_name] == aliased_command.name }
       end
 
       def alias_route_exists?(aliased_command)
-        self.class.routes.any? { |route| route.pattern.match(aliased_command.name) }
+        self.class.routes.any? { |route| route.extensions[:alias_name] == aliased_command.name }
       end
     end
 

--- a/spec/lita/alias/chat_handler_spec.rb
+++ b/spec/lita/alias/chat_handler_spec.rb
@@ -47,6 +47,12 @@ describe Lita::Alias::ChatHandler, lita_handler: true do
           send_command('FOO')
           expect(replies.last).to eq 'BAR'
         end
+
+        it 'responds with extra args' do
+          send_command('alias add SAY echo')
+          send_command('SAY HELLO')
+          expect(replies.last).to eq 'HELLO'
+        end
       end
 
       context 'existing alias' do

--- a/spec/lita/alias/chat_handler_spec.rb
+++ b/spec/lita/alias/chat_handler_spec.rb
@@ -35,7 +35,7 @@ describe Lita::Alias::ChatHandler, lita_handler: true do
       it 'returns current listing' do
         send_command('alias add FOO echo BAR')
         send_command('alias list')
-        expect(replies.last).to eq ['FOO => echo BAR']
+        expect(replies.last).to eq 'FOO => echo BAR'
       end
     end
 


### PR DESCRIPTION
Extra arguments given to invoked aliases may now be passed along to the original command. This allows whole classes of to be aliased/renamed `/alias jenkins jk` as well as commands that would otherwise require dynamic input `/alias build jenkins build job` -> `/build my-project`.

* Will not impact aliases run without arguments
* Includes appropriate spec testing
* Feature description added to README

I also noticed some unexpected behavior when aliases shared common substrings in their names. There was an edge case of infinite recursion in such instances, re-triggering the alias instead of the command. By updating the alias master route to require either whitespace or the EOL this ensures aliases are triggered only by "whole words".

Changing the master route interfered with the maintenance methods (exists/delete) which previously relied on trying to reverse match the alias name to the added route. These methods now use Lita's [route extensions flag](https://github.com/litaio/lita/blob/master/lib/lita/handler/chat_router.rb#L49) to directly store the name of the alias for future reference.